### PR TITLE
Add LAN games support.

### DIFF
--- a/src/main/java/org/geysermc/platform/fabric/GeyserServerPortGetter.java
+++ b/src/main/java/org/geysermc/platform/fabric/GeyserServerPortGetter.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.platform.fabric;
+
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * Represents a getter to the server port in the dedicated server and in the integrated server.
+ */
+public interface GeyserServerPortGetter {
+    /**
+     * Returns the server port.
+     *
+     * <ul>
+     *     <li>If it's a dedicated server, it will return the server port specified in the {@code server.properties} file.</li>
+     *     <li>If it's an integrated server, it will return the LAN port if opened, else -1.</li>
+     * </ul>
+     *
+     * The reason is that {@link MinecraftServer#getServerPort()} doesn't return the LAN port if it's the integrated server,
+     * and changing the behavior of this method via a mixin should be avoided as it could have unexpected consequences.
+     *
+     * @return The server port.
+     */
+    int geyser$getServerPort();
+}

--- a/src/main/java/org/geysermc/platform/fabric/mixin/client/IntegratedServerMixin.java
+++ b/src/main/java/org/geysermc/platform/fabric/mixin/client/IntegratedServerMixin.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.platform.fabric.mixin.client;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.integrated.IntegratedServer;
+import net.minecraft.world.GameMode;
+import org.geysermc.platform.fabric.GeyserFabricMod;
+import org.geysermc.platform.fabric.GeyserServerPortGetter;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Environment(EnvType.CLIENT)
+@Mixin(IntegratedServer.class)
+public class IntegratedServerMixin implements GeyserServerPortGetter {
+    @Shadow
+    private int lanPort;
+
+    @Inject(method = "openToLan", at = @At("RETURN"))
+    private void onOpenToLan(GameMode gameMode, boolean cheatsAllowed, int port, CallbackInfoReturnable<Boolean> cir) {
+        if (cir.getReturnValueZ()) {
+            // If the LAN is opened, starts Geyser.
+            GeyserFabricMod.getInstance().startGeyser((MinecraftServer) (Object) this);
+        }
+    }
+
+    @Override
+    public int geyser$getServerPort() {
+        return this.lanPort;
+    }
+}

--- a/src/main/java/org/geysermc/platform/fabric/mixin/server/MinecraftDedicatedServerMixin.java
+++ b/src/main/java/org/geysermc/platform/fabric/mixin/server/MinecraftDedicatedServerMixin.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.platform.fabric.mixin.server;
+
+import com.mojang.authlib.GameProfileRepository;
+import com.mojang.authlib.minecraft.MinecraftSessionService;
+import com.mojang.datafixers.DataFixer;
+import net.minecraft.resource.ResourcePackManager;
+import net.minecraft.resource.ServerResourceManager;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.WorldGenerationProgressListenerFactory;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.dedicated.MinecraftDedicatedServer;
+import net.minecraft.util.UserCache;
+import net.minecraft.util.registry.DynamicRegistryManager;
+import net.minecraft.world.SaveProperties;
+import net.minecraft.world.level.storage.LevelStorage;
+import org.geysermc.platform.fabric.GeyserServerPortGetter;
+import org.spongepowered.asm.mixin.Mixin;
+
+import java.net.Proxy;
+
+@Mixin(MinecraftDedicatedServer.class)
+public abstract class MinecraftDedicatedServerMixin extends MinecraftServer implements GeyserServerPortGetter
+{
+    // Constructor to compile
+    public MinecraftDedicatedServerMixin(Thread thread, DynamicRegistryManager.Impl impl, LevelStorage.Session session, SaveProperties saveProperties, ResourcePackManager resourcePackManager, Proxy proxy, DataFixer dataFixer, ServerResourceManager serverResourceManager, MinecraftSessionService minecraftSessionService, GameProfileRepository gameProfileRepository, UserCache userCache, WorldGenerationProgressListenerFactory worldGenerationProgressListenerFactory) {
+        super(thread, impl, session, saveProperties, resourcePackManager, proxy, dataFixer, serverResourceManager, minecraftSessionService, gameProfileRepository, userCache, worldGenerationProgressListenerFactory);
+    }
+
+    @Override
+    public int geyser$getServerPort() {
+        return this.getServerPort();
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -13,12 +13,15 @@
   },
   "license": "MIT",
   "icon": "assets/fabric/icon.png",
-  "environment": "server",
+  "environment": "*",
   "entrypoints": {
-    "server": [
+    "main": [
       "org.geysermc.platform.fabric.GeyserFabricMod"
     ]
   },
+  "mixins": [
+    "geyser-fabric.mixins.json"
+  ],
   "depends": {
     "fabricloader": ">=0.10.1+build.209",
     "fabric": "*",

--- a/src/main/resources/geyser-fabric.mixins.json
+++ b/src/main/resources/geyser-fabric.mixins.json
@@ -1,0 +1,14 @@
+{
+  "required": true,
+  "package": "org.geysermc.platform.fabric.mixin",
+  "compatibilityLevel": "JAVA_8",
+  "client": [
+    "client.IntegratedServerMixin"
+  ],
+  "server": [
+    "server.MinecraftDedicatedServerMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
+}


### PR DESCRIPTION
The method name `geyser$getServerPort` is purely to ensure that no mods will conflicts with this getter.

What has been done:
 - The mod initializer is now common between client and server.
 - Geyser will not start when client opens a new world, only when the client opens to LAN which can create a little lag for a moment the time for Geyser to starts.
 - 2 mixins and a duck interface were added to get the proper port in `auto` mode, explained the reason in the javadoc of `GeyserServerPortGetter`.

Hopefully I have respected the codestyle ^^