### PR TITLE
Refactor perms and upstream

### DIFF
--- a/src/main/java/org/geysermc/platform/fabric/GeyserFabricPermissions.java
+++ b/src/main/java/org/geysermc/platform/fabric/GeyserFabricPermissions.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.platform.fabric;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -33,6 +34,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GeyserFabricPermissions {
+
+    /**
+     * The minimum permission level a command source must have in order for it to run commands that are restricted
+     */
+    @JsonIgnore
+    public static final int RESTRICTED_MIN_LEVEL = 2;
 
     @JsonProperty("commands")
     private String[] commands;

--- a/src/main/java/org/geysermc/platform/fabric/command/FabricCommandSender.java
+++ b/src/main/java/org/geysermc/platform/fabric/command/FabricCommandSender.java
@@ -31,6 +31,7 @@ import net.minecraft.text.LiteralText;
 import org.geysermc.connector.GeyserConnector;
 import org.geysermc.connector.command.CommandSender;
 import org.geysermc.connector.common.ChatColor;
+import org.geysermc.platform.fabric.GeyserFabricMod;
 
 public class FabricCommandSender implements CommandSender {
 
@@ -57,5 +58,19 @@ public class FabricCommandSender implements CommandSender {
     @Override
     public boolean isConsole() {
         return !(source.getEntity() instanceof ServerPlayerEntity);
+    }
+
+    @Override
+    public boolean hasPermission(String s) {
+        // Mostly copied from fabric's world manager since the method there takes a GeyserSession
+
+        // Workaround for our commands because fabric doesn't have native permissions
+        for (GeyserFabricCommandExecutor executor : GeyserFabricMod.getInstance().getCommandExecutors()) {
+            if (executor.getCommand().getPermission().equals(s)) {
+                return executor.canRun(source);
+            }
+        }
+
+        return false;
     }
 }

--- a/src/main/java/org/geysermc/platform/fabric/world/GeyserFabricWorldManager.java
+++ b/src/main/java/org/geysermc/platform/fabric/world/GeyserFabricWorldManager.java
@@ -135,7 +135,7 @@ public class GeyserFabricWorldManager extends GeyserWorldManager {
         return false;
     }
 
-    public PlayerEntity getPlayer(GeyserSession session) {
+    private PlayerEntity getPlayer(GeyserSession session) {
         return server.getPlayerManager().getPlayer(session.getPlayerEntity().getUuid());
     }
 }

--- a/src/main/java/org/geysermc/platform/fabric/world/GeyserFabricWorldManager.java
+++ b/src/main/java/org/geysermc/platform/fabric/world/GeyserFabricWorldManager.java
@@ -42,6 +42,8 @@ import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.inventory.translators.LecternInventoryTranslator;
 import org.geysermc.connector.network.translators.world.GeyserWorldManager;
 import org.geysermc.connector.utils.BlockEntityUtils;
+import org.geysermc.platform.fabric.GeyserFabricMod;
+import org.geysermc.platform.fabric.command.GeyserFabricCommandExecutor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,7 +65,7 @@ public class GeyserFabricWorldManager extends GeyserWorldManager {
     public NbtMap getLecternDataAt(GeyserSession session, int x, int y, int z, boolean isChunkLoad) {
         Runnable lecternGet = () -> {
             // Mostly a reimplementation of Spigot lectern support
-            PlayerEntity player = server.getPlayerManager().getPlayer(session.getPlayerEntity().getUuid());
+            PlayerEntity player = getPlayer(session);
             if (player != null) {
                 BlockEntity blockEntity = player.world.getBlockEntity(new BlockPos(x, y, z));
                 if (!(blockEntity instanceof LecternBlockEntity lectern)) {
@@ -118,5 +120,22 @@ public class GeyserFabricWorldManager extends GeyserWorldManager {
             server.execute(lecternGet);
         }
         return LecternInventoryTranslator.getBaseLecternTag(x, y, z, 0).build();
+    }
+
+    @Override
+    public boolean hasPermission(GeyserSession session, String permission) {
+
+        // Workaround for our commands because fabric doesn't have native permissions
+        for (GeyserFabricCommandExecutor executor : GeyserFabricMod.getInstance().getCommandExecutors()) {
+            if (executor.getCommand().getPermission().equals(permission)) {
+                return executor.canRun(getPlayer(session).getCommandSource());
+            }
+        }
+
+        return false;
+    }
+
+    public PlayerEntity getPlayer(GeyserSession session) {
+        return server.getPlayerManager().getPlayer(session.getPlayerEntity().getUuid());
     }
 }

--- a/src/main/resources/permissions.yml
+++ b/src/main/resources/permissions.yml
@@ -1,10 +1,12 @@
 # Uncomment any commands that you wish to be run by clients
 # Commented commands require an OP permission of 2 or greater
 commands:
-#  - dump
   - help
+  - advancements
+  - statistics
+  - settings
   - offhand
 #  - list
 #  - reload
-#  - shutdown
 #  - version
+#  - dump


### PR DESCRIPTION
- implemented permission method, required by changes to upstream
- add all commands to permission.yml and remove `shutdown` 

Help command now has the same behaviour as other platforms.
Tab complete isn't filtered. It doesn't seem easy to do since with brigadier, the "requires" component does permission blocking and tab complete blocking at the same time. The permission blocking doesn't seem to be elegant at all though. 