### PR TITLE
Configure jitpack to use Java 17

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+before_install:
+  - export SDKMAN_DIR="/home/jitpack/.sdkman/"
+  - source "/home/jitpack/.sdkman/bin/sdkman-init.sh"
+  - sdk install java 17.0.1-open
+  - sdk use java 17.0.1-open


### PR DESCRIPTION
After 1fd181c40ad67ef7c0aa3d5061d03a2317e12a10 it appears like Geyser-Fabric is no longer pushed to the opencollab maven. Assuming this is intentional, this pr would at least allow Jitpack to function on this repo. This is the same method [lithium](https://github.com/CaffeineMC/lithium-fabric/blob/1.18.x/dev/jitpack.yml) also uses.