### PR TITLE
Update for Java 1.19 and Geyser 2.0.4-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.
 
-    implementation 'org.geysermc:core:2.0.4-SNAPSHOT'
-    shadow('org.geysermc:core:2.0.4-SNAPSHOT') {
+    implementation "org.geysermc:core:${project.mod_version}"
+    shadow("org.geysermc:core:${project.mod_version}") {
         exclude group: 'com.google.guava', module: "guava"
         exclude group: 'com.google.code.gson', module: "gson"
         exclude group: 'org.slf4j'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.10-SNAPSHOT'
+    id 'fabric-loom' version '0.12-SNAPSHOT'
     id 'maven-publish'
     id 'com.github.johnrengelman.shadow' version '7.0.0'
     id 'java'
@@ -27,8 +27,8 @@ dependencies {
     // PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
     // You may need to force-disable transitiveness on them.
 
-    implementation 'org.geysermc:core:2.0.3-SNAPSHOT'
-    shadow('org.geysermc:core:2.0.3-SNAPSHOT') {
+    implementation 'org.geysermc:core:2.0.4-SNAPSHOT'
+    shadow('org.geysermc:core:2.0.4-SNAPSHOT') {
         exclude group: 'com.google.guava', module: "guava"
         exclude group: 'com.google.code.gson', module: "gson"
         exclude group: 'org.slf4j'
@@ -93,7 +93,7 @@ jar {
 
 remapJar {
     dependsOn(shadowJar)
-    input.set shadowJar.archiveFile.get()
+    input = tasks.shadowJar.archiveFile
 }
 
 // configure the maven publication

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 # Done to increase the memory available to gradle.
-org.gradle.jvmargs=-Xmx1G
+org.gradle.jvmargs=-Xmx2G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.18.2
-yarn_mappings=1.18.2+build.1
-loader_version=0.12.8
+minecraft_version=1.19
+yarn_mappings=1.19+build.1
+loader_version=0.14.6
 # Mod Properties
-mod_version=2.0.3-SNAPSHOT
+mod_version=2.0.4-SNAPSHOT
 maven_group=org.geysermc.platform
 archives_base_name=Geyser-Fabric
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.43.1+1.18
+fabric_version=0.55.2+1.19

--- a/src/main/java/org/geysermc/platform/fabric/command/FabricCommandSender.java
+++ b/src/main/java/org/geysermc/platform/fabric/command/FabricCommandSender.java
@@ -27,7 +27,7 @@ package org.geysermc.platform.fabric.command;
 
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 import org.geysermc.geyser.GeyserImpl;
 import org.geysermc.geyser.command.CommandSender;
 import org.geysermc.geyser.text.ChatColor;
@@ -49,7 +49,7 @@ public class FabricCommandSender implements CommandSender {
     @Override
     public void sendMessage(String message) {
         if (source.getEntity() instanceof ServerPlayerEntity) {
-            ((ServerPlayerEntity) source.getEntity()).sendMessage(new LiteralText(message), false);
+            ((ServerPlayerEntity) source.getEntity()).sendMessage(Text.literal(message), false);
         } else {
             GeyserImpl.getInstance().getLogger().info(ChatColor.toANSI(message + ChatColor.RESET));
         }

--- a/src/main/java/org/geysermc/platform/fabric/mixin/client/IntegratedServerMixin.java
+++ b/src/main/java/org/geysermc/platform/fabric/mixin/client/IntegratedServerMixin.java
@@ -30,7 +30,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.integrated.IntegratedServer;
-import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
 import net.minecraft.world.GameMode;
 import org.geysermc.geyser.text.GeyserLocale;
 import org.geysermc.platform.fabric.GeyserFabricMod;
@@ -58,7 +58,7 @@ public class IntegratedServerMixin implements GeyserServerPortGetter {
             // Ensure player locale has been loaded, in case it's different from Java system language
             GeyserLocale.loadGeyserLocale(this.client.options.language);
             // Give indication that Geyser is loaded
-            this.client.player.sendMessage(new LiteralText(GeyserLocale.getPlayerLocaleString("geyser.core.start",
+            this.client.player.sendMessage(Text.literal(GeyserLocale.getPlayerLocaleString("geyser.core.start",
                     this.client.options.language, "localhost", String.valueOf(this.lanPort))), false);
         }
     }

--- a/src/main/java/org/geysermc/platform/fabric/mixin/server/MinecraftDedicatedServerMixin.java
+++ b/src/main/java/org/geysermc/platform/fabric/mixin/server/MinecraftDedicatedServerMixin.java
@@ -25,27 +25,23 @@
 
 package org.geysermc.platform.fabric.mixin.server;
 
-import com.mojang.authlib.GameProfileRepository;
-import com.mojang.authlib.minecraft.MinecraftSessionService;
 import com.mojang.datafixers.DataFixer;
 import net.minecraft.resource.ResourcePackManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.SaveLoader;
 import net.minecraft.server.WorldGenerationProgressListenerFactory;
 import net.minecraft.server.dedicated.MinecraftDedicatedServer;
-import net.minecraft.util.UserCache;
+import net.minecraft.util.ApiServices;
 import net.minecraft.world.level.storage.LevelStorage;
 import org.geysermc.platform.fabric.GeyserServerPortGetter;
-import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 
 import java.net.Proxy;
 
 @Mixin(MinecraftDedicatedServer.class)
 public abstract class MinecraftDedicatedServerMixin extends MinecraftServer implements GeyserServerPortGetter {
-    // Constructor to compile
-    public MinecraftDedicatedServerMixin(Thread serverThread, LevelStorage.Session session, ResourcePackManager dataPackManager, SaveLoader saveLoader, Proxy proxy, DataFixer dataFixer, @Nullable MinecraftSessionService sessionService, @Nullable GameProfileRepository gameProfileRepo, @Nullable UserCache userCache, WorldGenerationProgressListenerFactory worldGenerationProgressListenerFactory) {
-        super(serverThread, session, dataPackManager, saveLoader, proxy, dataFixer, sessionService, gameProfileRepo, userCache, worldGenerationProgressListenerFactory);
+    public MinecraftDedicatedServerMixin(Thread serverThread, LevelStorage.Session session, ResourcePackManager dataPackManager, SaveLoader saveLoader, Proxy proxy, DataFixer dataFixer, ApiServices apiServices, WorldGenerationProgressListenerFactory worldGenerationProgressListenerFactory) {
+        super(serverThread, session, dataPackManager, saveLoader, proxy, dataFixer, apiServices, worldGenerationProgressListenerFactory);
     }
 
     @Override

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,6 @@
   "depends": {
     "fabricloader": ">=0.11.3",
     "fabric": "*",
-    "minecraft": ">=1.18.2"
+    "minecraft": ">=1.19"
   }
 }


### PR DESCRIPTION
Seemed to work without any issues on LAN and a dedicated server.
I wasn't able to test with Floodgate since it hasn't been updated for Fabric 1.19 yet.