### PR TITLE
Relocate dependencies to resolve incompatibilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,9 @@ shadowJar {
     relocate("org.yaml", "org.geysermc.relocate.yaml") // https://github.com/CardboardPowered/cardboard/issues/139
     relocate("com.fasterxml.jackson", "org.geysermc.relocate.jackson")
     relocate("net.kyori", "org.geysermc.relocate.kyori")
+    relocate("com.google", "org.geysermc.relocate.google")
+    relocate("it.unimi.dsi.fastutil", "org.geysermc.relocate.fastutil")
+    relocate("org.slf4j", "org.geysermc.relocate.slf4j")
 }
 
 jar {


### PR DESCRIPTION
This fixes three client crashes caused by using Geyser-Fabric with certain mods:

1. Relocating `com.google` fixes [an exception](https://hastebin.com/raw/ohahawobih) when clicking "Create New World". Not sure which mod causes this (I use quite a few other mods), but it happens on both Fabric and Quilt.
2. Relocating `it.unimi.dsi.fastutil` fixes [an exception](https://hastebin.com/raw/wigayoqonu) during mixin transformation. This only happens on Quilt, and it seems to be an incompatibility with Lithium.
3. Relocating `org.slf4j` fixes [an exception](https://hastebin.com/raw/taxirifaqe) during launch. This also only happens on Quilt, and it seems to be an incompatibility with Iris.